### PR TITLE
Added saving map-specific cmds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 src/env.py
 logs/
+
+storage/*.db
+src/test.py
+idea.txt

--- a/src/api.py
+++ b/src/api.py
@@ -89,3 +89,6 @@ def hold_key(x, duration):
         WINDOW.send(x, blocking=True, press_duration=duration * 1000)
     except AttributeError:
         logging.info(f"[CODE] Window not active. {x} was not sent to the client.")
+
+def reset_visuals():
+    api.exec_command(f"df_chs1_Info6 0;r_picmip 0;r_gamma 1;r_mapoverbrightbits 2;df_mp_NoDrawRadius 100;cg_drawgun 1")

--- a/src/mapdata.py
+++ b/src/mapdata.py
@@ -1,0 +1,61 @@
+"""
+This is the map data module
+it allows us to save and load meta data related to each map
+For now used to store data about gamma / reshade settings /  other visual stuff
+But could be used in the future for any map specific data
+"""
+
+import sqlite3
+import os.path
+import json
+
+STORAGE_PATH = "../storage/mapdata.db"
+MAPDATA_TABLE = "mapdata"
+
+singleton = lambda c: c()
+
+@singleton
+class MapData(object):
+    def __init__(self):
+        if not os.path.isfile(STORAGE_PATH):
+            open(STORAGE_PATH, "x")
+
+        self.con = sqlite3.connect(STORAGE_PATH)
+        self.cur = self.con.cursor()
+
+        # id (integer representing row id), mapname (string representing map name), data (json string that represents all data required)
+        # we use json for data since it allows us to extra data for the future without having to change the database schema
+        self.cur.execute(f"CREATE TABLE IF NOT EXISTS {MAPDATA_TABLE} (id INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE, mapname TEXT, data TEXT)")
+        self.con.commit()
+
+    def load(self, mapname):
+        result = self.cur.execute(f'SELECT * FROM {MAPDATA_TABLE} WHERE mapname = ? LIMIT 1', (mapname,)).fetchone()
+
+        return result
+
+    def save(self, mapname, key, value):
+        result = self.load(mapname)
+
+        if result is None:
+            data = {
+                key: value
+            }
+
+            self.cur.execute(f'INSERT INTO {MAPDATA_TABLE} (mapname, data) VALUES (?, ?)', (
+                mapname,
+                json.dumps(data)
+            ))
+        else:
+            data = json.loads(result[2])
+            data[key] = value
+
+            self.cur.execute(f'UPDATE {MAPDATA_TABLE} SET data =  ? WHERE id = ?', (
+                json.dumps(data),
+                result[0]
+            ))
+
+        self.con.commit()
+
+    def clear(self, mapname):
+        self.cur.execute(f'DELETE FROM {MAPDATA_TABLE} WHERE mapname = ?  LIMIT 1', (mapname,))
+        self.con.commit()

--- a/src/mapdata.py
+++ b/src/mapdata.py
@@ -8,9 +8,47 @@ But could be used in the future for any map specific data
 import sqlite3
 import os.path
 import json
+import serverstate
+import time
+import api
+import logging
 
 STORAGE_PATH = "../storage/mapdata.db"
 MAPDATA_TABLE = "mapdata"
+
+SAVED_CMDS = {
+    "angles" : {
+        "cmd": "df_chs1_Info6",
+        "default": 0
+    },
+    "gamma": {
+        "cmd": "r_gamma",
+        "default": 1
+    },
+    "nodraw": {
+        "cmd": "df_mp_NoDrawRadius",
+        "default": 100
+    },
+    "drawgun": {
+        "cmd": "cg_drawgun",
+        "default": 1
+    },
+}
+
+
+# brightness and picmip require vid_restarting, not sure how to handle it
+"""
+    "brightness": {
+        "cmd": "r_mapoverbrightbits",
+        "default": 2
+    },
+    "picmip": {
+        "cmd": "r_picmip",
+        "default": 0
+    }
+"""
+
+CURRENT_MAP = None
 
 singleton = lambda c: c()
 
@@ -20,20 +58,26 @@ class MapData(object):
         if not os.path.isfile(STORAGE_PATH):
             open(STORAGE_PATH, "x")
 
-        self.con = sqlite3.connect(STORAGE_PATH)
-        self.cur = self.con.cursor()
+        con = sqlite3.connect(STORAGE_PATH)
+        cur = con.cursor()
 
         # id (integer representing row id), mapname (string representing map name), data (json string that represents all data required)
         # we use json for data since it allows us to extra data for the future without having to change the database schema
-        self.cur.execute(f"CREATE TABLE IF NOT EXISTS {MAPDATA_TABLE} (id INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE, mapname TEXT, data TEXT)")
-        self.con.commit()
+        cur.execute(f"CREATE TABLE IF NOT EXISTS {MAPDATA_TABLE} (id INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE, mapname TEXT, data TEXT)")
+        con.commit()
+        con.close()
 
     def load(self, mapname):
-        result = self.cur.execute(f'SELECT * FROM {MAPDATA_TABLE} WHERE mapname = ? LIMIT 1', (mapname,)).fetchone()
+        con = sqlite3.connect(STORAGE_PATH)
+        cur = con.cursor()
+        result = cur.execute(f'SELECT * FROM {MAPDATA_TABLE} WHERE mapname = ? LIMIT 1', (mapname,)).fetchone()
 
+        con.close()
         return result
 
     def save(self, mapname, key, value):
+        con = sqlite3.connect(STORAGE_PATH)
+        cur = con.cursor()
         result = self.load(mapname)
 
         if result is None:
@@ -41,7 +85,7 @@ class MapData(object):
                 key: value
             }
 
-            self.cur.execute(f'INSERT INTO {MAPDATA_TABLE} (mapname, data) VALUES (?, ?)', (
+            cur.execute(f'INSERT INTO {MAPDATA_TABLE} (mapname, data) VALUES (?, ?)', (
                 mapname,
                 json.dumps(data)
             ))
@@ -49,13 +93,74 @@ class MapData(object):
             data = json.loads(result[2])
             data[key] = value
 
-            self.cur.execute(f'UPDATE {MAPDATA_TABLE} SET data =  ? WHERE id = ?', (
+            cur.execute(f'UPDATE {MAPDATA_TABLE} SET data =  ? WHERE id = ?', (
                 json.dumps(data),
                 result[0]
             ))
 
-        self.con.commit()
+        con.commit()
+        con.close()
 
-    def clear(self, mapname):
-        self.cur.execute(f'DELETE FROM {MAPDATA_TABLE} WHERE mapname = ?  LIMIT 1', (mapname,))
-        self.con.commit()
+    # toggles key between value and default, if key doesn't exist, set it to value
+    def toggle(self, mapname, key, value, default):
+        result = self.load(mapname)
+
+        save = value
+
+        if result is not None:
+            data = json.loads(result[2])
+            if key in data and data[key] == value:
+                save = default
+
+        self.save(mapname, key, save)
+        
+    # remove specific key-value pair from data
+    def clear(self, mapname, key):
+        con = sqlite3.connect(STORAGE_PATH)
+        cur = con.cursor()
+        result = self.load(mapname)
+
+        if result is None:
+            return
+
+        data = json.loads(result[2])
+        data.pop(key, None)
+
+        cur.execute(f'UPDATE {MAPDATA_TABLE} SET data =  ? WHERE id = ?', (
+            json.dumps(data),
+            result[0]
+        ))
+        con.commit()
+        con.close()
+
+    # delete all data related to a specific map
+    def delete(self, mapname):
+        con = sqlite3.connect(STORAGE_PATH)
+        cur = con.cursor()
+        cur.execute(f'DELETE FROM {MAPDATA_TABLE} WHERE mapname = ?', (mapname,))
+        con.commit()
+        con.close()
+
+# mapdataHook is a hook that is used to check when map changes
+# if it does, then it applies data from the database to the current map
+def mapdataHook():
+    global CURRENT_MAP
+    while True:
+        if serverstate.STATE.mapname != CURRENT_MAP and serverstate.STATE.mapname != None:
+            CURRENT_MAP = serverstate.STATE.mapname
+            logging.info("Map changed to : " + str(CURRENT_MAP))
+
+            data = MapData.load(CURRENT_MAP)
+            cmd = f"cg_centertime 3;displaymessage 140 10 Changing settings for map: {CURRENT_MAP}"
+
+            if data is not None:
+                data = json.loads(data[2])
+                for key, value in SAVED_CMDS.items():
+                    if key in data:
+                        cmd += ";" + SAVED_CMDS[key]['cmd'] + " " + str(data[key])
+                    else:
+                        cmd += ";" + SAVED_CMDS[key]['cmd'] + " " + str(SAVED_CMDS[key]['default'])
+
+            api.exec_command(cmd)
+
+        time.sleep(4)

--- a/src/serverstate.py
+++ b/src/serverstate.py
@@ -17,6 +17,8 @@ import config
 import os
 import servers
 import logging
+import threading
+import mapdata
 
 
 # Configurable variables, Strike = 2seconds
@@ -36,6 +38,8 @@ VID_RESTARTING = False
 STATE_INITIALIZED = False
 LAST_REPORT_TIME = time.time()
 LAST_INIT_REPORT_TIME = time.time()
+
+mapdata_thread = threading.Thread(target=mapdata.mapdataHook, daemon=True)
 
 
 class State:
@@ -252,6 +256,9 @@ def initialize_state():
         logging.info("[CODE] State Initialized.")
     except:
         return False
+
+    if not mapdata_thread.is_alive():
+        mapdata_thread.start()
 
     return True
 

--- a/src/twitch_commands.py
+++ b/src/twitch_commands.py
@@ -17,6 +17,7 @@ import logging
 from datetime import datetime
 import sys
 import pathlib
+from mapdata import MapData
 
 USE_WHITELIST = 0
 
@@ -85,10 +86,13 @@ async def cgaz(ctx, author, args):
 
 async def nodraw(ctx, author, args):
     api.exec_command(f"toggle df_mp_NoDrawRadius 100 100000;cg_centertime 3;displaymessage 140 10 ^3{author} ^7has changed: ^3Players visibility")
+    MapData.toggle(serverstate.STATE.mapname, 'nodraw', 100000, 100)
+    
 
 
 async def angles(ctx, author, args):
     api.exec_command(f"toggle df_chs1_Info6 0 40;cg_centertime 3;displaymessage 140 10 ^3{author} ^7has changed: ^3Weapon angles")
+    MapData.toggle(serverstate.STATE.mapname, 'angles', 40, 0)
 
 
 async def obs(ctx, author, args):
@@ -97,6 +101,7 @@ async def obs(ctx, author, args):
 
 async def drawgun(ctx, author, args):
     api.exec_command(f"toggle cg_drawgun 1 2;cg_centertime 3;displaymessage 140 10 ^3{author} ^7has changed: ^3Gun movement")
+    MapData.toggle(serverstate.STATE.mapname, 'drawgun', 2, 1)
 
 
 async def clean(ctx, author, args):
@@ -193,6 +198,7 @@ async def brightness(ctx, author, args):
         serverstate.VID_RESTARTING = True
         serverstate.PAUSE_STATE = True
         api.exec_command(f"r_mapoverbrightbits {value};vid_restart")
+        MapData.save(serverstate.STATE.mapname, 'brightness', value)
     else:
         await ctx.channel.send(f" {author}, the valid values for brightness are 1-5.")
 
@@ -209,6 +215,7 @@ async def picmip(ctx, author, args):
         serverstate.VID_RESTARTING = True
         serverstate.PAUSE_STATE = True
         api.exec_command(f"r_picmip {value};vid_restart")
+        MapData.save(serverstate.STATE.mapname, 'picmip', value)
     else:
         await ctx.channel.send(f"{author}, the allowed values for picmip are 0-5.")
 
@@ -223,5 +230,6 @@ async def gamma(ctx, author, args):
     if 1.0 <= int(value) <= 1.6:
         logging.info("[CODE] i did it..")
         api.exec_command(f"r_gamma {value}")
+        MapData.save(serverstate.STATE.mapname, 'gamma', value)
     else:
         await ctx.channel.send(f"{author}, the allowed values for gamma are 1.0-1.6")


### PR DESCRIPTION
This makes it such that when a twitch user changes a visual about a specific map (?angles...), it's saved in an sqlite3 local database
so that subsequent connection to the same map use the previous settings.
